### PR TITLE
Fix multiple integers in cmd.

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 						Aliases: []string{"str", "s"},
 						Usage:   "string argument (separate multiple values by comma)",
 					},
-					&cli.IntFlag{
+					&cli.StringFlag{
 						Name:    "int",
 						Aliases: []string{"i"},
 						Usage:   "integer 32 argument (separate multiple values by comma)",


### PR DESCRIPTION
This allows to send multiple integers in the same call:
.\osc-utility_0.2.1_windows_amd64.exe message --host 127.0.0.1 --address /OBSBOT/WebCam/General/SetGimMotorDegree --port 16284 --int 45,45,10

Since when sending multiple integers, the param turns into string, IntFlag prevents from parsing the command through SetIntegers function.

![image](https://github.com/user-attachments/assets/fba88ce8-6b1a-44c5-8333-ac50333bb46d)
